### PR TITLE
Improves error handling on process spawn

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -94,6 +94,14 @@ class EcaServer {
                 }
             });
 
+            this._proc.on('error', (err) => {
+                this._channel.appendLine(`[VSCODE] server process error: ${err}`);
+                if (this._status !== EcaServerStatus.Stopped &&
+                    this._status !== EcaServerStatus.Failed) {
+                    this.changeStatus(EcaServerStatus.Failed);
+                }
+            });
+
             this._proc.stderr.on('data', (data) => {
                 this._channel.appendLine(data.toString());
             });


### PR DESCRIPTION
When the process does not spawn correctly or closes right after it starts, ECA was stuck in the `Running` state.

This PR:
 - add listeners to `close` and `error`
 - append message to the output channel
 - Change the ECA server status to `Failed`.