### PR TITLE
improve error handling when fail to find version

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -131,7 +131,14 @@ class EcaServer {
                 this.connection.sendNotification(ecaApi.initialized, {});
                 this._onStarted(this.connection);
             });
-        }).catch((err) => console.error('Fail to find eca server path.', err));
+        }).catch((err) => {
+            this._channel.appendLine(`[VSCODE] Fail to find eca server path: ${err}`);
+            if (this._status !== EcaServerStatus.Stopped &&
+                this._status !== EcaServerStatus.Failed) {
+                this.changeStatus(EcaServerStatus.Failed);
+            }
+        }
+        );
     }
 
     async stop() {


### PR DESCRIPTION
`eca-vscode` throws an error if it fails to find a version ([ref](https://github.com/editor-code-assistant/eca-vscode/blob/a91a2c813c6d682da260afe5dbbbfc08a8ea52a8/src/server.ts#L289)), but the error was not handled correctly.
This PR changes the `catch` to send the error message in the `_channel` and also change the status of ECA to `failed`.