### PR TITLE
fix: open file was opening config files

### DIFF
--- a/src/webview.ts
+++ b/src/webview.ts
@@ -157,9 +157,11 @@ export class EcaWebviewProvider implements vscode.WebviewViewProvider {
                 case 'editor/openFile': {
                     const fileUri = vscode.Uri.file(message.data.path);
                     vscode.window.showTextDocument(fileUri);
+                    return;
                 }
                 case 'editor/openServerLogs': {
                     this._channel.show();
+                    return;
                 }
                 case 'editor/openGlobalConfig': {
                     const homedir = os.homedir();


### PR DESCRIPTION
## Problem
When using the open file option in ECA chat, it was opening the file but also the config file.

## Solution
Add missing return statement to cases