### PR TITLE
fix: prevent macOS code signature error when updating running ECA binary

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -222,6 +222,11 @@ class EcaServerPathFinder {
                     })
                     .on('error', reject);
             });
+
+            if (fs.existsSync(serverPath)) {
+                await fs.promises.rm(serverPath, { force: true });
+            }
+
             if (path.extname(downloadPath) === '.zip') {
                 await extractZip.default(downloadPath, { dir: extensionPath });
             }


### PR DESCRIPTION
# Problem
The downloadLatestServer() method was directly extracting the new binary to overwrite the existing file. When a binary is overwritten while another process has it loaded in memory, macOS enforces code signing integrity and terminates the new process attempting to use the modified binary.

# Solution
Delete the existing binary before extracting the new version.

**Changes**
 - Added file existence check before extraction
 - Delete existing binary using fs.promises.rm() with force: true option
 - New binary is extracted cleanly to the path without conflicts

## How to reproduce
To reproduce the original issue and verify the fix:
 - Open VSCode instance with ECA running
 - Remove the `eca-version` file in the plugin folder (e.g. `/Users/<user>/.vscode/extensions/editor-code-assistant.eca-<version>/`)
 - Open a second VSCode instance, will trigger ECA download
 - Verify the first instance continues running with the old version

Without the fix:
 - Verify the second instance do not starts successfully
With the fix:
 - Verify the second instance starts successfully

### Related
This matches the behavior of the IntelliJ plugin which also deletes the binary before extracting:
https://github.com/editor-code-assistant/eca-intellij/blob/e582ba57031dda11fce44c535acacd8ac3e6bdfb/src/main/clojure/dev/eca/eca_intellij/server.clj#L79-L80

