### PR TITLE
Fix macOS global config path to match ECA server

### DIFF
--- a/src/editor-actions.ts
+++ b/src/editor-actions.ts
@@ -47,9 +47,8 @@ export interface EditorWriteGlobalConfigResult {
  *   1. `ECA_CONFIG_PATH` environment variable (absolute path), if set.
  *   2. `$XDG_CONFIG_HOME/eca/config.json` if `XDG_CONFIG_HOME` is set.
  *   3. Platform default:
- *      - darwin:  `~/Library/Application Support/eca/config.json`
  *      - win32:   `%APPDATA%\eca\config.json` (falls back to `~/.config/eca/config.json`)
- *      - others:  `~/.config/eca/config.json`
+ *      - others (macOS, Linux):  `~/.config/eca/config.json`
  *
  * Note: this does not touch the filesystem. Creation is the caller's
  * responsibility.
@@ -63,10 +62,6 @@ export function getGlobalConfigPath(): string {
     const xdg = process.env.XDG_CONFIG_HOME;
     if (xdg && xdg.trim().length > 0) {
         return path.join(xdg, 'eca', 'config.json');
-    }
-
-    if (process.platform === 'darwin') {
-        return path.join(os.homedir(), 'Library', 'Application Support', 'eca', 'config.json');
     }
 
     if (process.platform === 'win32') {


### PR DESCRIPTION
## Summary
- Remove the darwin-specific branch in `getGlobalConfigPath()` that resolved to `~/Library/Application Support/eca/config.json`
- The ECA server uses `~/.config/eca/config.json` on all platforms (including macOS), so the Settings → Global Config tab was pointing to the wrong file
- This regression was introduced in commit `3a1eeeb` which ported the path logic from eca-desktop

## Context
The original inline logic in `webview.ts` correctly used `~/.config/eca/config.json` on all platforms. When the new `editor-actions.ts` module was extracted (commit `3a1eeeb`), it copied eca-desktop's darwin-specific branch that diverges from the ECA server. The companion fix for eca-desktop is at editor-code-assistant/eca-desktop#(see linked PR).

## Test plan
- [x] Verified the path resolves to `~/.config/eca/config.json` on macOS
- [x] eca-desktop test suite passes with the same change

🤖 Generated with [eca](https://eca.dev)